### PR TITLE
Update GIMP.download.recipe

### DIFF
--- a/GIMP/GIMP.download.recipe
+++ b/GIMP/GIMP.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>href='//download.gimp.org/mirror/pub/gimp/v(.*)/osx/'</string>
+				<string>href="//download.gimp.org/mirror/pub/gimp/v(.*)/osx/"</string>
 				<key>url</key>
 				<string>https://www.gimp.org/downloads/</string>
 				<key>result_output_var_name</key>


### PR DESCRIPTION
The download is still failing... looking at the source code of https://www.gimp.org/downloads/
I see the href with double quotation marks: <a href="//download.gimp.org/gimp/v2.10/osx/gimp-2.10.32-x86_64.dmg">
                    Download GIMP&nbsp;2.10.32<br>
                    directly
                </a>